### PR TITLE
add packer for azure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vagrant/
 .terraform/
+.kitchen/
 pkg/
 doc/
 priv/

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -51,7 +51,8 @@ The `script/azure_cli.sh` script will create a ssh key in /vagrant/priv/id_rsa a
     ```bash
     
     #project prefix
-    export TF_VAR_prefix=daniele
+    export prefix=daniele
+    export TF_VAR_prefix=${prefix}
 
     #Azure creds
     export ARM_SUBSCRIPTION_ID=your_subscription_id

--- a/terraform/packer/.kitchen.yml
+++ b/terraform/packer/.kitchen.yml
@@ -1,0 +1,28 @@
+driver:
+  name: azurerm
+  subscription_id: <%= ENV['ARM_SUBSCRIPTION_ID'] %>
+  location: 'East US'
+  machine_size: 'Standard_DS2_v2'
+
+transport:
+  ssh_key: ~/.ssh/id_rsa
+
+provisioner:
+  name: shell
+
+platforms:
+  - name: azure/xenial64
+    driver:
+      image_id: /subscriptions/<%= ENV['ARM_SUBSCRIPTION_ID'] %>/resourceGroups/<%= ENV['prefix'] %>ResourceGroupForVM/providers/Microsoft.Compute/images/xenial64
+      vm_name: myxenial64
+      vm_tags:
+        ostype: linux
+        distro: ubuntu
+      use_managed_disk: true
+
+verifier:
+  name: inspec
+
+suites:
+  - name: default
+

--- a/terraform/packer/README.md
+++ b/terraform/packer/README.md
@@ -1,0 +1,21 @@
+
+
+# pre-req
+
+chefdk-2.5.3-1.dmg
+
+gem install kitchen-azurerm
+
+# process
+
+packer build xenial64.json
+
+kitchen test
+
+kitchen destroy
+
+packer build -force xenial64.json
+
+kitchen test
+
+kitchen destroy

--- a/terraform/packer/README.md
+++ b/terraform/packer/README.md
@@ -4,7 +4,7 @@
 
 chefdk-2.5.3-1.dmg
 
-gem install kitchen-azurerm
+chef gem install kitchen-azurerm
 
 # process
 

--- a/terraform/packer/scripts/azure_cleanup.sh
+++ b/terraform/packer/scripts/azure_cleanup.sh
@@ -1,0 +1,6 @@
+apt-get autoremove -y
+apt-get clean
+
+/usr/sbin/waagent -force -deprovision+user
+export HISTSIZE=0
+sync

--- a/terraform/packer/scripts/packages.sh
+++ b/terraform/packer/scripts/packages.sh
@@ -1,0 +1,37 @@
+mkdir -p /etc/dpkg/dpkg.cfg.d
+cat >/etc/dpkg/dpkg.cfg.d/01_nodoc <<EOF
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/lintian/*
+path-exclude /usr/share/linda/*
+EOF
+
+export DEBIAN_FRONTEND=noninteractive
+export APTARGS="-qq -o=Dpkg::Use-Pty=0"
+
+apt-get clean ${APTARGS}
+apt-get update ${APTARGS}
+
+apt-get upgrade -y ${APTARGS}
+apt-get dist-upgrade -y ${APTARGS}
+
+# Update to the latest kernel
+apt-get install -y linux-generic linux-image-generic ${APTARGS}
+
+# pip
+apt-get install -y python-pip ${APTARGS}
+apt-get install -y python3-pip ${APTARGS}
+
+# git
+apt-get install -y git ${APTARGS}
+
+# Hide Ubuntu splash screen during OS Boot, so you can see if the boot hangs
+apt-get remove -y plymouth-theme-ubuntu-text
+sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="quiet"/GRUB_CMDLINE_LINUX_DEFAULT=""/' /etc/default/grub
+update-grub
+
+# Reboot with the new kernel
+shutdown -r now

--- a/terraform/packer/test/integration/default/check_pkg.rb
+++ b/terraform/packer/test/integration/default/check_pkg.rb
@@ -1,0 +1,11 @@
+describe package('wget') do
+  it { should be_installed }
+end
+
+describe package('python-pip') do
+  it { should be_installed }
+end
+
+describe package('python3-pip') do
+  it { should be_installed }
+end

--- a/terraform/packer/test/integration/default/gen.sh
+++ b/terraform/packer/test/integration/default/gen.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+pkg="wget"
+
+for p in ${pkg} ; do echo "describe package('${p}') do
+  it { should be_installed }
+end
+"
+done

--- a/terraform/packer/tf_resourcegroup/main.tf
+++ b/terraform/packer/tf_resourcegroup/main.tf
@@ -1,0 +1,41 @@
+variable "prefix" {
+  default = "daniele"
+}
+
+variable "datacenter" {
+  default = "eastus"
+}
+
+variable "ARM_SUBSCRIPTION_ID" {
+  description = "The Azure subscription ID"
+}
+
+variable "ARM_CLIENT_ID" {
+  description = "The Azure client ID"
+}
+
+variable "ARM_CLIENT_SECRET" {
+  description = "The Azure secret access key"
+}
+
+variable "ARM_TENANT_ID" {
+  description = "The Azure tenant ID"
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  subscription_id = "${var.ARM_SUBSCRIPTION_ID}"
+  client_id       = "${var.ARM_CLIENT_ID}"
+  client_secret   = "${var.ARM_CLIENT_SECRET}"
+  tenant_id       = "${var.ARM_TENANT_ID}"
+}
+
+# Create a resource group if it doesn’t exist
+resource "azurerm_resource_group" "terraformgroup" {
+  name     = "${var.prefix}ResourceGroupForVM"
+  location = "${var.datacenter}"
+
+  tags {
+    environment = "${var.prefix} Terraform Demo"
+  }
+}

--- a/terraform/packer/xenial64.json
+++ b/terraform/packer/xenial64.json
@@ -1,0 +1,45 @@
+{
+    "variables": {
+      "client_id": "{{ env `ARM_CLIENT_ID` }}",
+      "client_secret": "{{env `ARM_CLIENT_SECRET` }}",
+      "tenant_id": "{{env `ARM_TENANT_ID`}}",
+      "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+      "resource_group_name": "{{env `prefix`}}ResourceGroupForVM",
+      "image_name": "xenial64"
+    },
+    "builders": [
+      {
+        "type": "azure-arm",
+        "client_id": "{{user `client_id`}}",
+        "client_secret": "{{user `client_secret`}}",
+        "tenant_id": "{{user `tenant_id`}}",
+        "subscription_id": "{{user `subscription_id`}}",
+        "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+        "managed_image_name": "{{user `image_name`}}",
+        "os_type": "Linux",
+        "image_publisher": "Canonical",
+        "image_offer": "UbuntuServer",
+        "image_sku": "16.04-LTS",
+        "azure_tags": {
+          "dept": "Engineering",
+          "task": "Image deployment"
+        },
+        "location": "East US",
+        "vm_size": "Standard_DS2_v2"
+      }
+    ],
+    "provisioners": [
+      {
+        "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -H -E sh '{{ .Path }}'",
+        "expect_disconnect": true,
+        "script": "scripts/packages.sh",
+        "type": "shell"
+      },
+      {
+        "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -H -E sh '{{ .Path }}'",
+        "script": "scripts/azure_cleanup.sh",
+        "type": "shell"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
this PR adds a packer setup w/kitchen test to move from a general box into a custom made one.

This is just the base building block where we will move work from the template, into the base box to follow immutable infrastructure principles.